### PR TITLE
Bump mocha version to 1.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test": "grunt"
   },
   "dependencies": {
-    "mocha": "1.8.1"
+    "mocha": "~1.9.0"
   },
   "devDependencies": {
     "grunt": "~0.3.17",


### PR DESCRIPTION
Because old mocha uses `process.nextTick` for recursive deferral, tests may fail in node 0.10.0 or later.

Example:
https://travis-ci.org/Constellation/esmangle/jobs/6129843
