### PR TITLE
Add `mocha` option to allow overriding Mocha

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,21 @@ mochaTest: {
 
 NB. The `require` option can only be used with Javascript files, ie. it is not possible to specify a `./globals.coffee` in the above example.
 
+### Specifying a Mocha module
+
+If you would like to use a different version of Mocha than the one packaged with this plugin, you can specify the module with the `mocha` option:
+
+```
+mochaTest: {
+  test: {
+    options: {
+      mocha: require('mocha')
+    },
+    src: ['test/**/*.coffee']
+  }
+}
+```
+
 ### Generating coverage reports
 
 Here is an example gruntfile that registers 2 test tasks, 1 to run the tests and 1 to generate a coverage report using `blanket.js` to instrument the javascript on the fly.

--- a/tasks/lib/MochaWrapper.js
+++ b/tasks/lib/MochaWrapper.js
@@ -1,4 +1,3 @@
-var Mocha = require('mocha');
 var domain = require('domain');
 var fs = require('fs');
 var path = require('path');
@@ -23,6 +22,7 @@ function MochaWrapper(params) {
     });
   }
 
+  var Mocha = params.options.mocha || require('mocha');
   var mocha = new Mocha(params.options);
 
   params.files.forEach(function(file) {

--- a/test/scenarios/mochaOption/Gruntfile.js
+++ b/test/scenarios/mochaOption/Gruntfile.js
@@ -1,0 +1,23 @@
+module.exports = function(grunt) {
+  // Add our custom tasks.
+  grunt.loadTasks('../../../tasks');
+
+  // Project configuration.
+  grunt.initConfig({
+    mochaTest: {
+      options: {
+        reporter: 'spec'
+      },
+      all: {
+        options: {
+          mocha: function() { throw new Error('Custom Mocha constructor.'); },
+          captureFile: 'output'
+        },
+        src: ['*.js']
+      }
+    }
+  });
+
+  // Default task.
+  grunt.registerTask('default', ['mochaTest']);
+};

--- a/test/tasks/grunt-mocha-test.js
+++ b/test/tasks/grunt-mocha-test.js
@@ -307,4 +307,19 @@ describe('grunt-mocha-test', function() {
       done();
     });
   });
+
+  it('should support the mocha option', function(done) {
+    var destinationFile = __dirname + '/../scenarios/mochaOption/output';
+
+    // first remove the destination file
+    if (fs.existsSync(destinationFile)) {
+      fs.unlinkSync(destinationFile);
+    }
+
+    execScenario('mochaOption', function(error, stdout, stderr) {
+      expect(stdout).to.match(/Custom Mocha constructor/);
+      expect(stderr).to.equal('');
+      done();
+    });
+  });
 });


### PR DESCRIPTION
This feature allows users to supply the plugin with a version of Mocha
of their choosing. This means the latest version of Mocha can be
injected without needing to update this task, and older versions of
Mocha can be used in test environments that depend on deprecated
behavior.
