### PR TITLE
Invalid require cache to allow multiple test runs in the same process

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,57 @@ Don't forget to update `package.json` with options for `travis-cov`, for example
   ...
 ```
 
+### Running in permanent environments (like watch)
+
+In some instances, for example when you are running grunt-mocha-test in a grunt watch environment using the `spawn: false` option, you might get in a spot where each test is run only once. After that it will be ignored until
+you always get: `0 passing` as a result of your tests.
+
+This happens because mocha loads your test using require. Thus once it has been loaded once in a specific process, it won't run again. To prevent this from happening, use the `clearRequireCache` option (default value is `false`).
+
+Here is an example allowing you to run only the modified tests when possible:
+
+```javascript
+module.exports = function(grunt) {
+
+  grunt.loadNpmTasks('grunt-mocha-test');
+  grunt.loadNpmTasks('grunt-contrib-watch');
+
+  grunt.initConfig({
+    mochaTest: {
+      test: {
+        options: {
+          reporter: 'spec',
+          clearRequireCache: true
+        },
+        src: ['test/**/*.js']
+      },
+    },
+
+    watch: {
+      js: {
+        options: {
+          spawn: false,
+        },
+        files: '**/*.js',
+        tasks: ['check']
+      }
+    }
+  });
+
+  // On watch events configure mochaTest to run only on the test if it is one
+  // otherwise, run the whole testsuite
+  var defaultSimpleSrc = grunt.config('mochaTest.simple.src');
+  grunt.event.on('watch', function(action, filepath) {
+    grunt.config('mochaTest.simple.src', defaultSimpleSrc);
+    if (filepath.match('test/')) {
+      grunt.config('mochaTest.simple.src', filepath);
+    }
+  });
+
+  grunt.registerTask('default', 'mochaTest');
+};
+```
+
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using: 
 

--- a/tasks/lib/MochaWrapper.js
+++ b/tasks/lib/MochaWrapper.js
@@ -25,6 +25,12 @@ function MochaWrapper(params) {
 
   var mocha = new Mocha(params.options);
 
+  if (params.options.clearRequireCache === true) {
+    Object.keys(require.cache).forEach(function (key) {
+      delete require.cache[key];
+    });
+  }
+
   params.files.forEach(function(file) {
     file.src.forEach(mocha.addFile.bind(mocha));
   });

--- a/test/scenarios/clearRequireCacheOption/Gruntfile.js
+++ b/test/scenarios/clearRequireCacheOption/Gruntfile.js
@@ -1,0 +1,28 @@
+module.exports = function(grunt) {
+  // Add our custom tasks.
+  grunt.loadTasks('../../../tasks');
+
+  // Project configuration.
+  grunt.initConfig({
+    mochaTest: {
+      options: {
+        reporter: 'spec'
+      },
+      on: {
+        options: {
+          clearRequireCache: true
+        },
+        src: ['teston.js']
+      },
+      off: {
+        options: {
+          clearRequireCache: false
+        },
+        src: ['testoff.js']
+      }
+    }
+  });
+
+  // Default task.
+  grunt.registerTask('default', ['mochaTest:off', 'mochaTest:on']);
+};

--- a/test/scenarios/clearRequireCacheOption/testoff.js
+++ b/test/scenarios/clearRequireCacheOption/testoff.js
@@ -1,0 +1,8 @@
+var expect = require('chai').expect;
+var path = require('path');
+
+describe('check content of require cache contain tasks/mocha.js', function() {
+  it('should pass', function() {
+    expect(require.cache).to.have.property(path.resolve(__dirname, '../../../tasks/mocha.js'));
+  });
+});

--- a/test/scenarios/clearRequireCacheOption/teston.js
+++ b/test/scenarios/clearRequireCacheOption/teston.js
@@ -1,0 +1,8 @@
+var expect = require('chai').expect;
+var path = require('path');
+
+describe('check content of require cache does not contain tasks/mocha.js', function() {
+  it('should pass', function() {
+    expect(require.cache).not.to.have.property(path.resolve(__dirname, '../../../tasks/mocha.js'));
+  });
+});

--- a/test/tasks/grunt-mocha-test.js
+++ b/test/tasks/grunt-mocha-test.js
@@ -152,6 +152,19 @@ describe('grunt-mocha-test', function() {
     });
   });
 
+  it('should support the clearRequireCacheOption', function(done) {
+    execScenario('clearRequireCacheOption', function(error, stdout, stderr) {
+      expect(stdout).to.match(/mochaTest:on/);
+      expect(stdout).to.match(/mochaTest:off/);
+      expect(stdout).to.match(/1 passing/);
+      expect(stdout).not.to.match(/0 passing/);
+      expect(stdout).not.to.match(/2 passing/);
+      expect(stdout).to.match(/Done, without errors./);
+      expect(stderr).to.equal('');
+      done();
+    });
+  });
+
   it('should support the grep option', function(done) {
     execScenario('grepOption', function(error, stdout, stderr) {
       expect(stdout).to.match(/tests that match grep/);


### PR DESCRIPTION
This fix a behaviour causing grunt-watch with "spawn: false" option to play badly with grunt-mocha-test. This fix should hopefully make things better.
