### PR TITLE
CoffeeScript 1.7's compiler must be registered explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ mochaTest: {
   test: {
     options: {
       reporter: 'spec',
-      require: 'coffee-script'
+      require: 'coffee-script/register'
     },
     src: ['test/**/*.coffee']
   }
@@ -88,7 +88,7 @@ mochaTest: {
     options: {
       reporter: 'spec',
       require: [
-        'coffee-script',
+        'coffee-script/register',
         './globals.js'
       ]
     },

--- a/test/scenarios/requireCompilersOption/Gruntfile.coffee
+++ b/test/scenarios/requireCompilersOption/Gruntfile.coffee
@@ -8,7 +8,7 @@ module.exports = (grunt) ->
       options:
         reporter: 'spec',
         require: [
-          'coffee-script',
+          'coffee-script/register',
           './globals'
         ]
       all:

--- a/test/scenarios/requireCompilersOption/test.coffee
+++ b/test/scenarios/requireCompilersOption/test.coffee
@@ -6,3 +6,5 @@ describe 'test coffee-script', =>
     test = new Test 'Peter'
     expect(test.sayHello()).to.equal 'Hello, Peter'
     expect(testVar).to.equal 'test'
+    expect 1
+      .to.equal 1


### PR DESCRIPTION
CoffeeScript 1.7.0 brought this change:

```
When requiring CoffeeScript files in Node you must now explicitly register the compiler.
This can be done with require 'coffee-script/register' or CoffeeScript.register().
Also for configuration such as Mocha's, use coffee-script/register.
```

Without this change, coffee files get compiled using the version of coffee-script that comes with Grunt, which is currently at "~1.3.3".
