### PR TITLE
Failure to submit coverage results to coveralls should not be fatal

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -88,6 +88,9 @@ module.exports = function(grunt) {
       }
     },
     coveralls: {
+      options: {
+        force: true
+      },
       all: {
         src: 'lcov.info'
       }


### PR DESCRIPTION
https://travis-ci.org/pghalliday/grunt-mocha-test/builds/18518582
This build just failed because it "Failed to submit coverage results to coveralls"
