### PR TITLE
support for more detailed requires

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ mochaTest: {
 }
 ```
 
-In order to make this more user friendly the `require` option can take either a single file or an array of files in case you have other globals you wish to require.
+In order to make this more user friendly, the `require` option can take either a single file/function or an array of files/functions in case you have other globals you wish to require.
 
 eg.
 
@@ -89,7 +89,9 @@ mochaTest: {
       reporter: 'spec',
       require: [
         'coffee-script/register',
-        './globals.js'
+        './globals.js',
+        function(){ testVar1=require('./stuff'); },
+        function(){ testVar2='other-stuff'; }
       ]
     },
     src: ['test/**/*.coffee']
@@ -97,7 +99,7 @@ mochaTest: {
 }
 ```
 
-NB. The `require` option can only be used with Javascript files, ie. it is not possible to specify a `./globals.coffee` in the above example.
+NB. File references for the `require` option can only be used with Javascript files, ie. it is not possible to specify a `./globals.coffee` in the above example.
 
 ### Specifying a Mocha module
 

--- a/tasks/lib/MochaWrapper.js
+++ b/tasks/lib/MochaWrapper.js
@@ -14,11 +14,15 @@ function MochaWrapper(params) {
   if (params.options && params.options.require) {
     var mods = params.options.require instanceof Array ? params.options.require : [params.options.require];
     mods.forEach(function(mod) {
-      var abs = exists(mod) || exists(mod + '.js');
-      if (abs) {
-        mod = resolve(mod);
+      if (typeof mod === 'string') {
+        var abs = exists(mod) || exists(mod + '.js');
+        if (abs) {
+          mod = resolve(mod);
+        }
+        require(mod);
+      } else if (typeof mod === 'function') {
+        mod();
       }
-      require(mod);
     });
   }
 

--- a/test/scenarios/requireArrayOption/Gruntfile.js
+++ b/test/scenarios/requireArrayOption/Gruntfile.js
@@ -1,3 +1,5 @@
+/*global testVar4:true, testVar5:true*/
+
 module.exports = function(grunt) {
   // Add our custom tasks.
   grunt.loadTasks('../../../tasks');
@@ -7,7 +9,13 @@ module.exports = function(grunt) {
     mochaTest: {
       options: {
         reporter: 'spec',
-        require: ['require/common1', 'require/common2', 'require/common3']
+        require: [
+          'require/common1',
+          'require/common2',
+          'require/common3',
+          function(){ testVar4=require('./require/common4'); },
+          function(){ testVar5=':)'; }
+        ]
       },
       all: {
         src: ['*.js']

--- a/test/scenarios/requireArrayOption/require/common4.js
+++ b/test/scenarios/requireArrayOption/require/common4.js
@@ -1,0 +1,1 @@
+module.exports = ' ';

--- a/test/scenarios/requireArrayOption/test.js
+++ b/test/scenarios/requireArrayOption/test.js
@@ -1,4 +1,4 @@
-/*global testVar1:false, testVar2:false, testVar3:false*/
+/*global testVar1:false, testVar2:false, testVar3:false, testVar4:false, testVar5:false*/
 
 var expect = require('chai').expect;
 
@@ -7,5 +7,7 @@ describe('test', function() {
     expect(testVar1).to.equal('hello');
     expect(testVar2).to.equal('world');
     expect(testVar3).to.equal('!');
+    expect(testVar4).to.equal(' ');
+    expect(testVar5).to.equal(':)');
   });
 });


### PR DESCRIPTION
Example usage:

``` javascript
function requireChai() {
    expect = require("chai").expect;
}

function requireMain() {
    main = require("./lib/index.js");   // relative to Gruntfile
}

grunt.initConfig({
    mochaTest: {
        "single": {
            options: {
                require: requireMain,
                ui: "bdd"
            },
            src: ["test/*.js"]
        },
        "multiple": {
            options: {
                require: [requireMain, requireChai, "something-else"],
                ui: "bdd"
            },
            src: ["test/*.js"]
        }
    }
});
```
