### PR TITLE
[JSHint] Use "mocha" option instead of specifying globals explicitly

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,14 +25,7 @@ module.exports = function(grunt) {
         eqnull: true,
         node: true,
         strict: false,
-        globals: {
-          describe: false,
-          it: false,
-          suite: false,
-          test: false,
-          before: false,
-          after: false
-        }
+        mocha: true
       },
       all: {
         src: ['grunt.js', 'tasks/**/*.js', 'test/**/*.js']

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
   },
   "devDependencies": {
     "grunt-cli": "~0.1.13",
-    "grunt": "~0.4.2",
+    "grunt": "~0.4.4",
     "chai": "~1.9.0",
-    "grunt-contrib-jshint": "~0.9.2",
+    "grunt-contrib-jshint": "~0.10.0",
     "grunt-blanket": "~0.0.8",
     "grunt-contrib-copy": "~0.5.0",
     "grunt-contrib-clean": "~0.5.0",


### PR DESCRIPTION
From v2.5.0, JSHint supports the predefined functions of [Mocha](http://visionmedia.github.io/mocha/) with [`mocha` option](https://github.com/jshint/jshint/blob/20e2bee28242fa627e3a98087dda8713850941a9/src/jshint.js#L144).
See jshint/jshint#1597 for details.
