### PR TITLE
Fix CI setting to pass the test against Node v0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,7 @@ node_js:
   - "0.11"
   - "0.10"
   - "0.8"
+install:
+  - npm update npm -g
+  - npm install
 script: "npm run-script ci"


### PR DESCRIPTION
We can simply solve [this error](https://travis-ci.org/pghalliday/grunt-mocha-test/jobs/25898081) by updating [npm](https://www.npmjs.org/package/npm) to the latest version.

After merging this PR, we can merge #70, too.
