### PR TITLE
Use mkdirp and rimraf directly, instead of fs-extra

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     }
   },
   "dependencies": {
-    "fs-extra": "^0.12.0",
-    "hooker": "~0.2.3"
+    "hooker": "~0.2.3",
+    "mkdirp": "^0.5.0"
   },
   "peerDependencies": {
     "mocha": ">=1.20.0"
@@ -54,6 +54,7 @@
     "grunt-env": "~0.4.1",
     "mocha": "~2.0.0",
     "mocha-lcov-reporter": "0.0.1",
+    "rimraf": "^2.2.8",
     "travis-cov": "~0.2.5"
   },
   "keywords": [

--- a/tasks/mocha-test.js
+++ b/tasks/mocha-test.js
@@ -1,9 +1,10 @@
 'use strict';
 
 var MochaWrapper = require('./lib/MochaWrapper');
-var fs = require('fs-extra');
+var fs = require('fs');
 var path = require('path');
 var hooker = require('hooker');
+var mkdirpSync = require('mkdirp').sync;
 
 module.exports = function(grunt) {
 
@@ -11,7 +12,7 @@ module.exports = function(grunt) {
   var capture = function(captureFile, quiet, run, done) {
     var fd;
     if (captureFile) {
-      fs.mkdirsSync(path.dirname(captureFile));
+      mkdirpSync(path.dirname(captureFile));
       fd = fs.openSync(captureFile, 'w');
     }
     // Hook process.stdout.write

--- a/test/tasks/grunt-mocha-test.js
+++ b/test/tasks/grunt-mocha-test.js
@@ -2,11 +2,12 @@
 
 var expect = require('chai').expect;
 var path = require('path');
-var fs = require('fs-extra');
+var fs = require('fs');
 var ChildProcess = require('cover-child-process').ChildProcess;
 var Blanket = require('cover-child-process').Blanket;
 var childProcess = new ChildProcess(new Blanket());
 var gruntExec = 'node ' + path.resolve('node_modules/grunt-cli/bin/grunt');
+var rimrafSync = require('rimraf').sync;
 
 var execScenario = function(scenario, callback) {
   var scenarioDir = __dirname + '/../scenarios/' + scenario;
@@ -289,10 +290,7 @@ describe('grunt-mocha-test', function() {
     var destinationDirectory = path.join(__dirname, '/../scenarios/destinationFileCreateDirectories/reports');
     var destinationFile = path.join(destinationDirectory, 'output');
 
-    // first remove the destination directory
-    if (fs.existsSync(destinationDirectory)) {
-      fs.removeSync(destinationDirectory);
-    }
+    rimrafSync(destinationDirectory);
 
     execScenario('destinationFileCreateDirectories', function(error, stdout, stderr) {
       expect(stdout).to.match(/test1/);


### PR DESCRIPTION
- I added [mkdirp](https://github.com/substack/node-mkdirp) and [rimraf](https://github.com/isaacs/rimraf), and removed [fs-extra](https://github.com/jprichardson/node-fs-extra). This project doesn't need the gazillions of fs-extra's methods.
- I updated [chai](http://chaijs.com/) to v1.10.0.
