### PR TITLE
adding support for CLI parameters

### DIFF
--- a/tasks/mocha-test.js
+++ b/tasks/mocha-test.js
@@ -47,6 +47,14 @@ module.exports = function(grunt) {
     var options = this.options();
     var files = this.files;
 
+    // mocha CLI parameters
+    var params = ['grep', 'ui', 'reporter', 'timeout', 'invert', 'ignoreLeaks', 'growl', 'globals', 'require', 'colors', 'slow'];
+
+    // for every supplied CLI parameter overwrite task option
+    params.forEach(function(param) {
+      options[param] = grunt.option(param) || options[param];
+    });
+
     // check if there are files to test
     if (this.filesSrc.length === 0) {
       grunt.log.write('No files to check...');

--- a/test/scenarios/requireOption/Gruntfile.js
+++ b/test/scenarios/requireOption/Gruntfile.js
@@ -6,15 +6,20 @@ module.exports = function(grunt) {
   grunt.initConfig({
     mochaTest: {
       options: {
-        reporter: 'spec',
-        require: 'require/common'
+        reporter: 'spec'
       },
       all: {
+        src: ['*.js'],
+        options: {
+          require: 'require/common'
+        }
+      },
+      cli: {
         src: ['*.js']
       }
     }
   });
 
   // Default task.
-  grunt.registerTask('default', ['mochaTest']);
+  grunt.registerTask('default', ['mochaTest:all']);
 };

--- a/test/tasks/grunt-mocha-test.js
+++ b/test/tasks/grunt-mocha-test.js
@@ -9,14 +9,14 @@ var childProcess = new ChildProcess(new Blanket());
 var gruntExec = 'node ' + path.resolve('node_modules/grunt-cli/bin/grunt');
 var rimrafSync = require('rimraf').sync;
 
-var execScenario = function(scenario, callback) {
+var execScenario = function(command, scenario, callback) {
   var scenarioDir = __dirname + '/../scenarios/' + scenario;
-  childProcess.exec(gruntExec, {cwd: scenarioDir}, callback);
+  childProcess.exec(command, {cwd: scenarioDir}, callback);
 };
 
 describe('grunt-mocha-test', function() {
   it('should run tests from the supplied files', function(done) {
-    execScenario('tests', function(error, stdout, stderr) {
+    execScenario(gruntExec, 'tests', function(error, stdout, stderr) {
       expect(stdout).to.match(/test1/);
       expect(stdout).to.match(/test2/);
       expect(stdout).to.match(/2 passing/);
@@ -27,7 +27,7 @@ describe('grunt-mocha-test', function() {
   });
 
   it('should run tests from the supplied files with expand option', function(done) {
-    execScenario('testsExpand', function(error, stdout, stderr) {
+    execScenario(gruntExec, 'testsExpand', function(error, stdout, stderr) {
       expect(stdout).to.match(/test1/);
       expect(stdout).to.match(/test2/);
       expect(stdout).to.match(/2 passing/);
@@ -38,7 +38,7 @@ describe('grunt-mocha-test', function() {
   });
 
   it('should report the number of test failures and exit grunt with an error on failed tests', function(done) {
-    execScenario('testFailure', function(error, stdout, stderr) {
+    execScenario(gruntExec, 'testFailure', function(error, stdout, stderr) {
       expect(stdout).to.match(/test/);
       expect(stdout).to.match(/Aborted due to warnings./);
       expect(stderr).to.match(/1 failing/);
@@ -47,7 +47,7 @@ describe('grunt-mocha-test', function() {
   });
 
   it('should cleanly catch asynchronous test failures so that grunt does not exit early', function(done) {
-    execScenario('asyncTestFailure', function(error, stdout, stderr) {
+    execScenario(gruntExec, 'asyncTestFailure', function(error, stdout, stderr) {
       expect(stdout).to.match(/Asynchronous test/);
       expect(stdout).to.match(/Aborted due to warnings./);
       expect(stderr).to.match(/1 failing/);
@@ -56,7 +56,7 @@ describe('grunt-mocha-test', function() {
   });
 
   it('should cleanly catch and log require exceptions thrown synchronously by Mocha so that grunt does not exit early', function(done) {
-    execScenario('requireFailure', function(error, stdout, stderr) {
+    execScenario(gruntExec, 'requireFailure', function(error, stdout, stderr) {
       expect(stdout).to.match(/Cannot find module 'doesNotExist/);
       expect(stdout).to.match(/test.js/);
       expect(stdout).to.match(/Aborted due to warnings./);
@@ -66,7 +66,7 @@ describe('grunt-mocha-test', function() {
   });
 
   it('should cleanly catch and log net connect exceptions thrown asynchronously by Mocha so that grunt does not exit early', function(done) {
-    execScenario('connectFailure', function(error, stdout, stderr) {
+    execScenario(gruntExec, 'connectFailure', function(error, stdout, stderr) {
       expect(stdout).to.match(/Aborted due to warnings./);
       expect(stderr).to.match(/1 failing/);
       done();
@@ -74,7 +74,7 @@ describe('grunt-mocha-test', function() {
   });
 
   it('should cleanly catch and log exceptions thrown asynchronously by tests that have a before that starts an HTTP server', function(done) {
-    execScenario('asyncFailureWithBefore', function(error, stdout, stderr) {
+    execScenario(gruntExec, 'asyncFailureWithBefore', function(error, stdout, stderr) {
       expect(stdout).to.match(/async tests/);
       expect(stdout).to.match(/2 passing/);
       expect(stdout).to.match(/Aborted due to warnings./);
@@ -84,7 +84,17 @@ describe('grunt-mocha-test', function() {
   });
 
   it('should support the require option', function(done) {
-    execScenario('requireOption', function(error, stdout, stderr) {
+    execScenario(gruntExec, 'requireOption', function(error, stdout, stderr) {
+      expect(stdout).to.match(/test/);
+      expect(stdout).to.match(/1 passing/);
+      expect(stdout).to.match(/Done, without errors./);
+      expect(stderr).to.equal('');
+      done();
+    });
+  });
+
+  it('should support the require option via CLI', function(done) {
+    execScenario(gruntExec + " mochaTest:cli --require=require/common", 'requireOption', function(error, stdout, stderr) {
       expect(stdout).to.match(/test/);
       expect(stdout).to.match(/1 passing/);
       expect(stdout).to.match(/Done, without errors./);
@@ -94,7 +104,7 @@ describe('grunt-mocha-test', function() {
   });
 
   it('should support the colors option', function(done) {
-    execScenario('colorsOption', function(error, stdout, stderr) {
+    execScenario(gruntExec, 'colorsOption', function(error, stdout, stderr) {
       expect(stdout).to.match(/\u001b\[4mRunning \"mochaTest:all\" \(mochaTest\) task\u001b\[24m\n\n\n  test\n\r    ✓ should be ok \n\n\n  1 passing/);
       expect(stderr).to.equal('');
       done();
@@ -102,7 +112,7 @@ describe('grunt-mocha-test', function() {
   });
 
   it('should support the require option with arrays', function(done) {
-    execScenario('requireArrayOption', function(error, stdout, stderr) {
+    execScenario(gruntExec, 'requireArrayOption', function(error, stdout, stderr) {
       expect(stdout).to.match(/test/);
       expect(stdout).to.match(/1 passing/);
       expect(stdout).to.match(/Done, without errors./);
@@ -112,7 +122,7 @@ describe('grunt-mocha-test', function() {
   });
 
   it('should support the require option with complicated globals', function(done) {
-    execScenario('requireSingleton', function(error, stdout, stderr) {
+    execScenario(gruntExec, 'requireSingleton', function(error, stdout, stderr) {
       expect(stdout).to.match(/test1/);
       expect(stdout).to.match(/test2/);
       expect(stdout).to.match(/2 passing/);
@@ -123,7 +133,7 @@ describe('grunt-mocha-test', function() {
   });
 
   it('should support the require option with coffee-script', function(done) {
-    execScenario('requireCompilersOption', function(error, stdout, stderr) {
+    execScenario(gruntExec, 'requireCompilersOption', function(error, stdout, stderr) {
       expect(stdout).to.match(/test coffee-script/);
       expect(stdout).to.match(/1 passing/);
       expect(stdout).to.match(/Done, without errors./);
@@ -133,7 +143,7 @@ describe('grunt-mocha-test', function() {
   });
 
   it('should support the clearRequireCacheOption', function(done) {
-    execScenario('clearRequireCacheOption', function(error, stdout, stderr) {
+    execScenario(gruntExec, 'clearRequireCacheOption', function(error, stdout, stderr) {
       expect(stdout).to.match(/mochaTest:on/);
       expect(stdout).to.match(/mochaTest:off/);
       expect(stdout).to.match(/1 passing/);
@@ -146,7 +156,7 @@ describe('grunt-mocha-test', function() {
   });
 
   it('should support the clearRequireCacheOption with the require option', function(done) {
-    execScenario('clearRequireCacheAndRequireOptions', function(error, stdout, stderr) {
+    execScenario(gruntExec, 'clearRequireCacheAndRequireOptions', function(error, stdout, stderr) {
       expect(stdout).to.match(/test/);
       expect(stdout).to.match(/1 passing/);
       expect(stdout).to.match(/Done, without errors./);
@@ -156,7 +166,7 @@ describe('grunt-mocha-test', function() {
   });
 
   it('should support the grep option', function(done) {
-    execScenario('grepOption', function(error, stdout, stderr) {
+    execScenario(gruntExec, 'grepOption', function(error, stdout, stderr) {
       expect(stdout).to.match(/tests that match grep/);
       expect(stdout).to.match(/1 passing/);
       expect(stdout).to.match(/Done, without errors./);
@@ -166,7 +176,7 @@ describe('grunt-mocha-test', function() {
   });
 
   it('should support the invert option', function(done) {
-    execScenario('invertOption', function(error, stdout, stderr) {
+    execScenario(gruntExec, 'invertOption', function(error, stdout, stderr) {
       expect(stdout).to.match(/tests that don't match grep/);
       expect(stdout).to.match(/1 passing/);
       expect(stdout).to.match(/Done, without errors./);
@@ -176,7 +186,7 @@ describe('grunt-mocha-test', function() {
   });
 
   it('should support the ignoreLeaks option', function(done) {
-    execScenario('ignoreLeaksOption', function(error, stdout, stderr) {
+    execScenario(gruntExec, 'ignoreLeaksOption', function(error, stdout, stderr) {
       expect(stdout).to.match(/test/);
       expect(stdout).to.match(/Aborted due to warnings./);
       expect(stderr).to.match(/1 failing/);
@@ -186,7 +196,7 @@ describe('grunt-mocha-test', function() {
   });
 
   it('should support the globals option', function(done) {
-    execScenario('globalsOption', function(error, stdout, stderr) {
+    execScenario(gruntExec, 'globalsOption', function(error, stdout, stderr) {
       expect(stdout).to.match(/test/);
       expect(stdout).to.match(/1 passing/);
       expect(stdout).to.match(/Done, without errors./);
@@ -196,7 +206,7 @@ describe('grunt-mocha-test', function() {
   });
 
   it('should support the asyncOnly option', function(done) {
-    execScenario('asyncOnlyOption', function(error, stdout, stderr) {
+    execScenario(gruntExec, 'asyncOnlyOption', function(error, stdout, stderr) {
       expect(stdout).to.match(/test/);
       expect(stdout).to.match(/Aborted due to warnings./);
       expect(stderr).to.match(/1 failing/);
@@ -206,15 +216,23 @@ describe('grunt-mocha-test', function() {
   });
 
   it('should support the reporter option', function(done) {
-    execScenario('reporterOption', function(error, stdout, stderr) {
+    execScenario(gruntExec, 'reporterOption', function(error, stdout, stderr) {
       expect(stdout).to.match(/<section class="suite">/);
       expect(stderr).to.equal('');
       done();
     });
   });
 
+  it('should support the reporter option via CLI', function(done) {
+    execScenario(gruntExec + " --reporter=spec", 'reporterOption', function(error, stdout, stderr) {
+      expect(stdout).to.match(/Running "mochaTest:all"/);
+      expect(stderr).to.equal('');
+      done();
+    });
+  });
+
   it('should support the ui option', function(done) {
-    execScenario('uiOption', function(error, stdout, stderr) {
+    execScenario(gruntExec, 'uiOption', function(error, stdout, stderr) {
       expect(stdout).to.match(/test1/);
       expect(stdout).to.match(/test2/);
       expect(stdout).to.match(/2 passing/);
@@ -225,7 +243,7 @@ describe('grunt-mocha-test', function() {
   });
 
   it('should support using a custom ui option', function(done) {
-    execScenario('uiOptionCustom', function(error, stdout, stderr) {
+    execScenario(gruntExec, 'uiOptionCustom', function(error, stdout, stderr) {
       expect(stdout).to.match(/test/);
       expect(stdout).to.match(/1 passing/);
       expect(stdout).to.match(/Done, without errors./);
@@ -235,7 +253,7 @@ describe('grunt-mocha-test', function() {
   });
 
   it('should support the timeout option', function(done) {
-    execScenario('timeoutOption', function(error, stdout, stderr) {
+    execScenario(gruntExec, 'timeoutOption', function(error, stdout, stderr) {
       expect(stdout).to.match(/test/);
       expect(stdout).to.match(/Aborted due to warnings./);
       expect(stderr).to.match(/1 failing/);
@@ -245,10 +263,10 @@ describe('grunt-mocha-test', function() {
   });
 
   it('should support the growl option', function(done) {
-    execScenario('growlOption', function(error, stdout, stderr) { 
+    execScenario(gruntExec, 'growlOption', function(error, stdout, stderr) {
       // TODO: Let's just test that everything completed successfully
       // as there's no way of knowing if growl was actually called for now.
-      // A possible option would be to mock the growl binaries in the 
+      // A possible option would be to mock the growl binaries in the
       // growlOption scenario directory and have them do something that
       // the test can detect (HTTP server/request?). This would have to
       // be done for each platform though.
@@ -269,7 +287,7 @@ describe('grunt-mocha-test', function() {
       fs.unlinkSync(destinationFile);
     }
 
-    execScenario('destinationFile', function(error, stdout, stderr) {
+    execScenario(gruntExec, 'destinationFile', function(error, stdout, stderr) {
       expect(stdout).to.match(/test1/);
       expect(stdout).to.match(/test2/);
       expect(stdout).to.match(/2 passing/);
@@ -292,7 +310,7 @@ describe('grunt-mocha-test', function() {
 
     rimrafSync(destinationDirectory);
 
-    execScenario('destinationFileCreateDirectories', function(error, stdout, stderr) {
+    execScenario(gruntExec, 'destinationFileCreateDirectories', function(error, stdout, stderr) {
       expect(stdout).to.match(/test1/);
       expect(stdout).to.match(/test2/);
       expect(stdout).to.match(/2 passing/);
@@ -317,7 +335,7 @@ describe('grunt-mocha-test', function() {
       fs.unlinkSync(destinationFile);
     }
 
-    execScenario('quietOption', function(error, stdout, stderr) {
+    execScenario(gruntExec, 'quietOption', function(error, stdout, stderr) {
       expect(stdout).to.not.match(/test1/);
       expect(stdout).to.not.match(/test2/);
       expect(stdout).to.not.match(/2 passing/);
@@ -335,7 +353,7 @@ describe('grunt-mocha-test', function() {
   });
 
   it('should not run if the src config do not match any files', function(done) {
-    execScenario('noFiles', function(error, stdout, stderr) {
+    execScenario(gruntExec, 'noFiles', function(error, stdout, stderr) {
       expect(stdout).to.match(/No files to check.../);
       expect(stdout).to.match(/Done, without errors./);
       expect(stdout).not.to.match(/0 passing/);
@@ -345,7 +363,7 @@ describe('grunt-mocha-test', function() {
   });
 
   it('should work with grunt-env', function(done) {
-    execScenario('gruntEnvIntegration', function(error, stdout, stderr) {
+    execScenario(gruntExec, 'gruntEnvIntegration', function(error, stdout, stderr) {
       expect(stdout).to.match(/test/);
       expect(stdout).to.match(/1 passing/);
       expect(stdout).to.match(/Done, without errors./);


### PR DESCRIPTION
This support would allow you to override task options with command line parameters. This is particularly valuable in workflows where you need to quickly isolate tests and don't want to have to modify the underlying task. It also allows you to put `grunt-mocha-test` in a larger alias task and still pass through options via the command line.

**Mocha Test Task**

```
grunt mochaTest --reporter=nyan --grep=@smoke
```

**Alias Task**

```
grunt test:acceptance --reporter=spec --grep=@foo --invert=true
```
