### PR TITLE
make sure to call reporter.done if it exists

### DIFF
--- a/tasks/lib/MochaWrapper.js
+++ b/tasks/lib/MochaWrapper.js
@@ -73,7 +73,13 @@ function MochaWrapper(params) {
       runDomain.on('error', mochaRunner.uncaught.bind(mochaRunner));
       runDomain.run(function() {
         mochaRunner.run(function(failureCount) {
-          callback(null, failureCount);
+          if (mochaReporter.done) {
+            mochaReporter.done(failureCount, function(failureCount) {
+               callback(null, failureCount);
+            });
+          } else {
+            callback(null, failureCount);
+          }
         });
       });
       // I wish I could just do this...

--- a/test/scenarios/reporterOptions/test.js
+++ b/test/scenarios/reporterOptions/test.js
@@ -1,4 +1,6 @@
 describe('test', function() {
-  it('should be ok', function() {
-  });
+  for (var i = 0; i < 1000; ++i) {
+    it('should be ok ' + i, function() {
+    });
+  }
 });

--- a/test/tasks/grunt-mocha-test.js
+++ b/test/tasks/grunt-mocha-test.js
@@ -402,7 +402,7 @@ describe('grunt-mocha-test', function() {
 
     execScenario(gruntExec, 'reporterOptions', function(error, stdout, stderr) {
       expect(stdout).to.not.match(/test/);
-      expect(stdout).to.not.match(/tests="1"/);
+      expect(stdout).to.not.match(/tests="1000"/);
       expect(stdout).to.not.match(/failures="0"/);
       expect(stdout).to.not.match(/errors="0"/);
       expect(stdout).to.not.match(/skipped="0"/);
@@ -412,10 +412,12 @@ describe('grunt-mocha-test', function() {
       // now read the destination file
       var output = fs.readFileSync(destinationFile, 'utf8');
       expect(output).to.match(/test/);
-      expect(output).to.match(/tests="1"/);
+      expect(output).to.match(/tests="1000"/);
       expect(output).to.match(/failures="0"/);
       expect(output).to.match(/errors="0"/);
       expect(output).to.match(/skipped="0"/);
+      expect(output).to.match(/<testsuite.*>/);
+      expect(output).to.match(/<\/testsuite>/);
 
       done();
     });


### PR DESCRIPTION
For the xunit reporter to properly be able to write to a file, it needs to be kicked when mocha is done in order for it to properly flush all the data to the output file.

This PR adds the proper logic to call into the reporter.done when the test is complete and beefs up the testcase for the xunit file output to check that it properly writes out the </testsuite> line when a reasonably large run of 1000 tests is run. 