### PR TITLE
Allow to exclude directories

### DIFF
--- a/tasks/lib/MochaWrapper.js
+++ b/tasks/lib/MochaWrapper.js
@@ -35,15 +35,18 @@ function MochaWrapper(params) {
     });
   }
 
-  params.files.forEach(function(file, index, array) {
+    params.files.forEach(function(file, index, array) {
     file.src.forEach(function(src) {
+      var exclude = false;
       // Filter the files according to the exclussion pattern
       if(params.options.exclude) {
-        var exclude = [].concat(params.options.exclude).some(function(regexp) {
+        exclude = [].concat(params.options.exclude).some(function(regexp) {
             return src.match(regexp) != null;
         });
       }
-      if(!exclude) mocha.addFile.bind(mocha)(src);
+      if(!exclude) {
+        mocha.addFile.bind(mocha)(src);
+      }
     });
   });
 

--- a/tasks/lib/MochaWrapper.js
+++ b/tasks/lib/MochaWrapper.js
@@ -35,8 +35,16 @@ function MochaWrapper(params) {
     });
   }
 
-  params.files.forEach(function(file) {
-    file.src.forEach(mocha.addFile.bind(mocha));
+  params.files.forEach(function(file, index, array) {
+    file.src.forEach(function(src) {
+      // Filter the files according to the exclussion pattern
+      if(params.options.exclude) {
+        var exclude = [].concat(params.options.exclude).some(function(regexp) {
+            return src.match(regexp) != null;
+        });
+      }
+      if(!exclude) mocha.addFile.bind(mocha)(src);
+    });
   });
 
   this.run = function(callback) {


### PR DESCRIPTION
This is an incomplete change, but I'd like to get this functionality.

I've got a modular project structure, where each module has its own tests and dependencies. Something like this

> /
> |- node_modules
> |- module1
> |  |- ...
> |  |- node_modules
> |  |- test
> |- module2
> |  |- ...
> |  |- node_modules
> |  |- test
> |- test

Therefore, I tried configuring grunt-mocha-test like this:
```js
    mochaTest: {
      test: {
        options: {
          quiet: false, // Optionally suppress output to standard out (defaults to false)
          clearRequireCache: true // Optionally clear the require cache before running tests (defaults to false)
        },
        src: ['**/test/**/*.js']
      }
    }
```

The problem being that this way I'm performing every test of every dependency (which is not very convenient)

I decided to add a new option: `exclude`

It works with a regexp or an array of regexp, so I can do:

```js
    exclude: 'node_modules'
````

or

```js
    exclude: ['node_modules', 'bower_components']
````

Now, while this PR is functional, it doesn't include tests, and it still shows all the test files on verbose mode (even those ignored), because I couldn't manage to filter `params.files`.

I can give it a try if you find this PR convenient