### PR TITLE
Fork

### DIFF
--- a/tasks/lib/MochaWrapper.js
+++ b/tasks/lib/MochaWrapper.js
@@ -70,7 +70,10 @@ function MochaWrapper(params) {
             if (fd) {
               fs.writeSync(fd, result);
             }
-            
+            // Prevent the original process.stdout.write from executing if quiet was specified
+            if (params.options.quiet) {
+              return hooker.preempt();
+            }
           }
         });
       });

--- a/tasks/mocha-test.js
+++ b/tasks/mocha-test.js
@@ -4,39 +4,14 @@ var MochaWrapper = require('./lib/MochaWrapper');
 var fs = require('fs');
 var path = require('path');
 var hooker = require('hooker');
-var mkdirpSync = require('mkdirp').sync;
 
 module.exports = function(grunt) {
 
   // Helper to capture task output (adapted from tests for grunt-contrib-jshint)
   var capture = function(captureFile, quiet, run, done) {
-    var fd;
-    if (captureFile) {
-      mkdirpSync(path.dirname(captureFile));
-      fd = fs.openSync(captureFile, 'w');
-    }
-    // Hook process.stdout.write
-    hooker.hook(process.stdout, 'write', {
-      // This gets executed before the original process.stdout.write
-      pre: function(result) {
-        // Write result to file if it was opened
-        if (fd) {
-          fs.writeSync(fd, result);
-        }
-        // Prevent the original process.stdout.write from executing if quiet was specified
-        if (quiet) {
-          return hooker.preempt();
-        }
-      }
-    });
+    
     // Execute the code whose output is to be captured
     run(function(error, failureCount) {
-      // close the file if it was opened
-      if (fd) {
-        fs.closeSync(fd);
-      }
-      // Restore process.stdout.write to its original value
-      hooker.unhook(process.stdout, 'write');
       // Actually test the actually-logged stdout string to the expected value
       done(error, failureCount);
     });
@@ -91,6 +66,7 @@ module.exports = function(grunt) {
         } else {
           complete(null, failureCount);
         }
+       
       });
     }, function(error, failureCount) {
       // restore the uncaught exception handlers


### PR DESCRIPTION
# Main difference
On original `grunt-mocha-test` if you have a mocha test that use `console.log` and configuration like that 

    mochaTest: {
      'coverage': {
        options: {
          reporter: 'html-cov',
          quiet: true,
          captureFile: 'unit-tests.html',
        },
        src: ['test.js']
      },
    }

    the test

    describe('grunt-mocha-test', function() {
      it('should return 1', function(done) {
        console.log('It will out on report file');
        done();
      });
    });

In this case  the console output will be reported on report file, this fork  **fix it**. To it work the reporter need to write on the `runner.on('end')` event