### PR TITLE
add options.noFail to exit 0 on assertion failures

### DIFF
--- a/tasks/mocha-test.js
+++ b/tasks/mocha-test.js
@@ -95,6 +95,8 @@ module.exports = function(grunt) {
       restore();
       if (error) {
         done(false);
+      } else if (options.noFail) {
+        done(true);
       } else {
         done(failureCount === 0);
       }

--- a/test/scenarios/testFailureWithNoFail/Gruntfile.js
+++ b/test/scenarios/testFailureWithNoFail/Gruntfile.js
@@ -1,0 +1,14 @@
+var gruntShared = require('../../helpers/grunt-shared');
+module.exports = function(grunt) {
+  gruntShared(grunt, __dirname, {
+    mochaTest: {
+      options: {
+        noFail: true,
+        reporter: 'spec'
+      },
+      all: {
+        src: ['*.js']
+      }
+    }
+  });
+};

--- a/test/scenarios/testFailureWithNoFail/test.js
+++ b/test/scenarios/testFailureWithNoFail/test.js
@@ -1,0 +1,7 @@
+var expect = require('chai').expect;
+
+describe('test', function() {
+  it('should fail', function() {
+    expect(true).to.equal(false);
+  });
+});

--- a/test/tasks/grunt-mocha-test.js
+++ b/test/tasks/grunt-mocha-test.js
@@ -57,6 +57,17 @@ describe('grunt-mocha-test', function() {
     });
   });
 
+  it('should exit with code zero to allow structured reporters to differentiate runner failures from assertion failures', function(done) {
+    execScenario('testFailureWithNoFail', function(error, stdout, stderr) {
+      expect(stdout).to.match(/test/);
+      expect(stdout).to.match(/1\) should fail/);
+      expect(stdout).to.match(/1 failing/);
+      expect(stdout).to.match(/Done/);
+      expect(stderr).to.equal('');
+      done();
+    });
+  });
+
   it('should cleanly catch asynchronous test failures so that grunt does not exit early', function(done) {
     execScenario('asyncTestFailure', function(error, stdout, stderr) {
       expect(stdout).to.match(/Asynchronous test/);


### PR DESCRIPTION
Fixes #124 

I'm open to better names for the option, but this will allow Jenkins and other systems that accept structured result output to differentiate test failures (which get rendered as "unstable") from test runner failures (which get rendered as "failed'). In these scenarios, a test failure should still be treated as a success as far as exit code, thus allowing cleanup and test report processing. A test runner failure might be something like using `require: ['babel-register']` and encountering a syntax error.

Ideally, this would go into mocha core, but that looks like a much more complex change.