### PR TITLE
Add clearCacheFilter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ module.exports = function(grunt) {
           captureFile: 'results.txt', // Optionally capture the reporter output to a file
           quiet: false, // Optionally suppress output to standard out (defaults to false)
           clearRequireCache: false, // Optionally clear the require cache before running tests (defaults to false)
+          clearCacheFilter: (key) => true, // Optionally defines which files should keep in cache
           noFail: false // Optionally set to not fail on failed tests (will still fail on other errors)
         },
         src: ['test/**/*.js']
@@ -54,6 +55,7 @@ The following options are specific to `grunt-mocha-test` (ie. not mocha options)
 - `captureFile` - specify a file to capture all output to (will include any output from `console.log`)
 - `quiet` - `true` to not output anything to console (normally used with the `captureFile` option when console output would not be human readable)
 - `clearRequireCache` - `true` to clear the require cache before each test run (normally used with watch when not spawning each test run in a new `nodejs` context)
+- `clearCacheFilter` - `function() { return true/false }` to say which files should remain in cache. Only works with clearRequireCach set to `true`)
 - `noFail` - `true` to prevent the task failing on failed tests. Useful for CI setups where test reports are processed separately. Will still fail on other errors
 
 The following mocha options have also been tested (others may have been added since the time of writing through changes to mocha)

--- a/tasks/lib/MochaWrapper.js
+++ b/tasks/lib/MochaWrapper.js
@@ -29,9 +29,12 @@ function MochaWrapper(params) {
 
   var mocha = new Mocha(params.options);
 
+  var filterFunc = params.options.clearCacheFilter;
   if (params.options.clearRequireCache === true) {
     Object.keys(require.cache).forEach(function (key) {
-      delete require.cache[key];
+      if (typeof filterFunc !== 'function' || !filterFunc(key)) {
+        delete require.cache[key];
+      }
     });
   }
 

--- a/test/scenarios/clearCacheFilterOption/Gruntfile.js
+++ b/test/scenarios/clearCacheFilterOption/Gruntfile.js
@@ -1,0 +1,23 @@
+var gruntShared = require('../../helpers/grunt-shared');
+module.exports = function(grunt) {
+  gruntShared(grunt, __dirname, {
+    mochaTest: {
+      options: {
+        reporter: 'spec'
+      },
+      on: {
+        options: {
+          clearRequireCache: true,
+          clearCacheFilter: (key) => /mocha-test.js/.exec(key)
+        },
+        src: ['teston.js']
+      },
+      off: {
+        options: {
+          clearRequireCache: true
+        },
+        src: ['testoff.js']
+      }
+    }
+  }, ['mochaTest:on', 'mochaTest:off']);
+};

--- a/test/scenarios/clearCacheFilterOption/testoff.js
+++ b/test/scenarios/clearCacheFilterOption/testoff.js
@@ -1,0 +1,8 @@
+var expect = require('chai').expect;
+var path = require('path');
+
+describe('check content of require cache does not contain tasks/mocha.js', function() {
+  it('should pass', function() {
+    expect(require.cache).not.to.have.property(path.resolve(__dirname, '../../../tasks/mocha-test.js'));
+  });
+});

--- a/test/scenarios/clearCacheFilterOption/teston.js
+++ b/test/scenarios/clearCacheFilterOption/teston.js
@@ -1,0 +1,8 @@
+var expect = require('chai').expect;
+var path = require('path');
+
+describe('check content of require cache contain tasks/mocha.js', function() {
+  it('should pass', function() {
+    expect(require.cache).to.have.property(path.resolve(__dirname, '../../../tasks/mocha-test.js'));
+  });
+});

--- a/test/tasks/grunt-mocha-test.js
+++ b/test/tasks/grunt-mocha-test.js
@@ -297,7 +297,7 @@ describe('grunt-mocha-test', function() {
       expect(stdout).to.match(/test/);
       expect(stdout).to.match(/Aborted due to warnings./);
       expect(stdout).to.match(/1 failing/);
-      expect(stdout).to.match(/Error: timeout of 500ms exceeded/);
+      expect(stdout).to.match(/Error: Timeout of 500ms exceeded/);
       expect(stderr).to.equal('');
       done();
     });

--- a/test/tasks/grunt-mocha-test.js
+++ b/test/tasks/grunt-mocha-test.js
@@ -190,6 +190,19 @@ describe('grunt-mocha-test', function() {
     });
   });
 
+  it('should support the clearCacheFilterOption', function(done) {
+    execScenario('clearCacheFilterOption', function(error, stdout, stderr) {
+      expect(stdout).to.match(/mochaTest:on/);
+      expect(stdout).to.match(/mochaTest:off/);
+      expect(stdout).to.match(/1 passing/);
+      expect(stdout).not.to.match(/0 passing/);
+      expect(stdout).not.to.match(/2 passing/);
+      expect(stdout).to.match(/Done./);
+      expect(stderr).to.equal('');
+      done();
+    });
+  });
+
   it('should support the grep option', function(done) {
     execScenario('grepOption', function(error, stdout, stderr) {
       expect(stdout).to.match(/tests that match grep/);


### PR DESCRIPTION
The idea is to omit requiring large files (i.e. binary, json) to speed up testing and generating reports