### PR TITLE
Fix crash in Mocha v6 due to undefined options

### DIFF
--- a/tasks/mocha-test.js
+++ b/tasks/mocha-test.js
@@ -50,7 +50,10 @@ module.exports = function(grunt) {
 
     // for every supplied CLI parameter overwrite task option
     params.forEach(function(param) {
-      options[param] = grunt.option(param) || options[param];
+      var value = grunt.option(param) || options[param];
+      if(value) {
+        options[param] = value;
+      }
     });
 
     // check if there are files to test


### PR DESCRIPTION
Passing `undefined` options to mocha v6 cause it to break.
This PR just prevent passing the options object like this:
```javascript
{ 
  reporter: 'nyan',
  require: '@babel/register',
  grep: undefined,
  ui: undefined,
  timeout: undefined,
  invert: undefined,
  ignoreLeaks: undefined,
  growl: undefined,
  globals: undefined,
  colors: undefined,
  slow: undefined
}
```
And instead pass it like this:
```javascript
{ 
  reporter: 'nyan',
  require: '@babel/register'
}
```
Tests passing. No side effects.
Thank you for this package!